### PR TITLE
Tweak Dockerfile for Aptible push.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install libpq-dev nodejs
 ADD . /opt/rails
 WORKDIR /opt/rails
 RUN bundle install --without development test
-RUN cp config/database.yml.example config/database.yml
+# RUN cp config/database.yml.example config/database.yml
 RUN bundle exec rake assets:precompile
  
 ENV PORT 3000


### PR DESCRIPTION
Pushing to aptible fails, apparently because config/database.yml.example isn't recognized.
Let's try commenting out that line since that's not a file we have in our app.